### PR TITLE
css: set the cursor to pointer for expanders

### DIFF
--- a/json-grid.css
+++ b/json-grid.css
@@ -44,3 +44,7 @@
 .json-grid-container span.boolean {
   color: #0000ff;
 }
+
+.json-grid-container span.expander {
+  cursor: pointer;
+}


### PR DESCRIPTION
When hovering over the expander (+) boxes, I find it nice to have a hand-pointer. 