### PR TITLE
feat: Add expandAll/collapseAll support

### DIFF
--- a/JSONGrid.js
+++ b/JSONGrid.js
@@ -185,4 +185,58 @@ JSONGrid.prototype.render = function () {
   this.container.classList.add(DOMHelper.JSON_GRID_CONTAINER_CLASSNAME);
 };
 
+JSONGrid.prototype.expandAll = function () {
+  if (!this.container || !this.data) {
+    return;
+  }
+
+  var expanders = this.container.querySelectorAll('.expander');
+
+  expanders.forEach(function (expander) {
+    var tableId = expander.getAttribute(
+      DOMHelper.EXPANDER_TARGET_ATTRIBUTE
+    );
+
+    var table = document.getElementById(tableId);
+
+    if (
+      table &&
+      table.classList.contains(
+        DOMHelper.TABLE_SHRINKED_CLASSNAME
+      )
+    ) {
+      DOMHelper.onExpanderClick({
+        target: expander
+      });
+    }
+  });
+};
+
+JSONGrid.prototype.collapseAll = function () {
+  if (!this.container || !this.data) {
+    return;
+  }
+
+  var expanders = this.container.querySelectorAll('.expander');
+
+  expanders.forEach(function (expander) {
+    var tableId = expander.getAttribute(
+      DOMHelper.EXPANDER_TARGET_ATTRIBUTE
+    );
+
+    var table = document.getElementById(tableId);
+
+    if (
+      table &&
+      !table.classList.contains(
+        DOMHelper.TABLE_SHRINKED_CLASSNAME
+      )
+    ) {
+      DOMHelper.onExpanderClick({
+        target: expander
+      });
+    }
+  });
+};
+
 window.JSONGrid = JSONGrid;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JSON Grid
 
-JSON Grid is a open source javascript library meant to be run in the browser that aims to allow users to convert JSON objects into user-friendly and interactive tables/grids.
+JSON Grid is an open source Javascript library meant to be run in the browser that aims to allow users to convert JSON objects into user-friendly and interactive tables/grids.
 
-## Instalation
+## Installation
 
 In order to install, just require the package through `unpkg` (https://unpkg.com/@araujoigor/json-grid) and use the `JSONGrid` object to generate your grid.
 
@@ -72,14 +72,14 @@ A simple usage case would be:
 
 ## API
 
-The functions that are meant to be used publicily are:
+The functions that are meant to be used publicly are:
 
 ### `JSONGrid(data, container)`
 
 > The constructor receives two arguments: `data` and `container`.
 
 The `data` parameter is expected to be JSON object.
-The `container` paramenter is expected to be a DOM node and will be used to render the contents.
+The `container` parameter is expected to be a DOM node and will be used to render the contents.
 
 After the object is created, you can use the `render` function to render the grid.
 
@@ -90,3 +90,12 @@ Used to render grid based on the given `data` to the given `container`.
 ### `JSONGrid.prototype.generateDOM`
 
 Returns the grid DOM without rendering it to the `container`.
+
+### `JSONGrid.prototype.expandAll`
+
+Expands all collapsed tables and nested grids.
+
+
+### `JSONGrid.prototype.collapseAll`
+
+Collapses all expanded tables and nested grids.


### PR DESCRIPTION
This PR adds support for programmatically expanding and collapsing all nested tables.

## Changes
- Added `JSONGrid.prototype.expandAll`
- Added `JSONGrid.prototype.collapseAll`
- Added README documentation for the new API methods
- Fixed README typos and improved wording

## Example
```js
var jsonGrid = new JSONGrid(data, container);

jsonGrid.render();

// Collapse all nested grids
jsonGrid.collapseAll();

// Expand all nested grids
jsonGrid.expandAll();
```